### PR TITLE
Fix: skip code review when triggered by bot actor

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -35,6 +35,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: '*'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.sender.type == 'User'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -35,7 +36,6 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          allowed_bots: '*'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Summary
- Adds `if: github.event.sender.type == 'User'` to the `claude-review` job to prevent it from running when a bot (e.g. Claude) opens or updates a PR
- Removes the ineffective `allowed_bots: '*'` workaround added in a prior commit

## Problem
The code review workflow was failing with `Workflow initiated by non-human actor: claude` whenever the Claude bot created or updated a PR, causing an error loop.

## Test plan
- [ ] Open a PR as a human — code review should trigger normally
- [ ] Have a bot open/update a PR — code review job should be skipped (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)